### PR TITLE
Fix the name of GTK+ 3 python bindings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,6 @@ Ubuntu.
 
 The application is run as root.
 
-The application is implemented in PyGTK 3.0. If you want some other
+The application is implemented in Python 3 and GTK+ 3. If you want some other
 framework, you need to change the dependency list and the
 application's install command.


### PR DESCRIPTION
There is no such thing as PyGTK 3. PyGTK is the name of the old static (hand-written) bindings for GTK+ 2.
Since the use of GObject-introspection, the GTK+ 3 bindings are handled by PyGObject.
See https://pygobject.readthedocs.io